### PR TITLE
Harden fresh-machine bootstrap and agent install

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,4 +16,4 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
       - name: Run ShellCheck
-        run: shellcheck *.sh
+        run: git ls-files -z '*.sh' | xargs -0 shellcheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Portable instructions for any AI agent editing this repository.
 After editing shell scripts:
 
 ```bash
-shellcheck *.sh
+git ls-files '*.sh' | xargs shellcheck
 ```
 
 CI runs the same check (`.github/workflows/shellcheck.yml`).

--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,7 @@ brew "yq"
 brew "wget"
 brew "tree"
 brew "ripgrep"
+brew "shellcheck"
 
 # ── Zsh plugins ───────────────────────────────────────────────────────────────
 brew "zsh-autosuggestions"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ git config --global gpg.program gpg   # or /opt/homebrew/bin/gpg on Apple Silico
 | --- | --- |
 | Cursor | `~/.cursor/rules/*.mdc` (generated from `agent/manifest.tsv`) |
 | Claude Code | `~/.claude/CLAUDE.md` |
-| Workspace index | `~/myLab/AGENTS.md` and `~/myLab/CLAUDE.md` (symlink) |
+| Workspace index | `~/myLab/AGENTS.md` and `~/myLab/CLAUDE.md` (from `adapters/mylab-CLAUDE.md`) |
 
 Read `AGENTS.md` at the initMe repo root before editing bootstrap scripts.
 Open **`~/myLab`** as the Cursor workspace; optionally copy
@@ -210,7 +210,7 @@ and `~/myLab/AGENTS.md` adapters.
 Shell scripts are checked on push with [ShellCheck](https://www.shellcheck.net/) (see `.github/workflows/shellcheck.yml` and `.shellcheckrc`). Local check:
 
 ```bash
-shellcheck *.sh
+git ls-files '*.sh' | xargs shellcheck
 ```
 
 ## Keeping packages up to date

--- a/adapters/mylab-CLAUDE.md
+++ b/adapters/mylab-CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/agent/README.md
+++ b/agent/README.md
@@ -8,10 +8,10 @@ install tool-specific adapters:
 
 | Output | Source |
 | --- | --- |
-| `~/.cursor/rules/*.mdc` | `agent/*.md` + `agent/manifest.tsv` (YAML frontmatter added at install) |
+| `~/.cursor/rules/*.mdc` | `agent/*.md` + `agent/manifest.tsv` (YAML frontmatter added at install; stale rules pruned via `.initme-managed-rules`) |
 | `~/.claude/CLAUDE.md` | `adapters/claude-global.md` |
 | `~/myLab/AGENTS.md` | `templates/mylab-AGENTS.md` (when `~/myLab/` exists) |
-| `~/myLab/CLAUDE.md` | Symlink to `~/myLab/AGENTS.md` |
+| `~/myLab/CLAUDE.md` | `adapters/mylab-CLAUDE.md` (copied, not symlinked) |
 
 ## Layout
 

--- a/bootstrap-pi.sh
+++ b/bootstrap-pi.sh
@@ -52,7 +52,8 @@ if ! $DRY_RUN; then
         build-essential \
         libssl-dev \
         libffi-dev \
-        python3-dev
+        python3-dev \
+        shellcheck
 else
     echo "  [dry-run] would run: apt-get install git gnupg curl wget tree jq ripgrep zsh vim build-essential ..."
 fi

--- a/clone-mylab.sh
+++ b/clone-mylab.sh
@@ -21,7 +21,9 @@ clone_if_missing() {
   local dest="$MYLAB_DIR/$name"
 
   if [[ -d "$dest/.git" ]]; then
-    echo -e "${YELLOW}[skip]${NC} $name (already exists)"
+    echo -e "${YELLOW}[skip]${NC} $name (already cloned)"
+  elif [[ -d "$dest" ]]; then
+    echo -e "${YELLOW}[skip]${NC} $name (directory exists without .git — e.g. tarball install)"
   else
     echo -e "${GREEN}[clone]${NC} $name"
     git clone "$url" "$dest"

--- a/scripts/build-agent-adapters.sh
+++ b/scripts/build-agent-adapters.sh
@@ -7,6 +7,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 AGENT_DIR="$REPO_DIR/agent"
 MANIFEST="$AGENT_DIR/manifest.tsv"
 CURSOR_RULES_DIR="${CURSOR_RULES_DIR:-$HOME/.cursor/rules}"
+CURSOR_STAMP="$CURSOR_RULES_DIR/.initme-managed-rules"
 
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
@@ -27,11 +28,52 @@ link_file() {
   info "Linked $dst -> $src"
 }
 
+install_file() {
+  local src="$1" dst="$2"
+  if [[ -L "$dst" ]]; then
+    rm "$dst"
+  elif [[ -f "$dst" ]]; then
+    warn "Backing up existing $dst -> ${dst}.bak"
+    mv "$dst" "${dst}.bak"
+  fi
+  cp "$src" "$dst"
+  info "Installed $dst"
+}
+
+prune_removed_cursor_rules() {
+  local -a current=("$@")
+  [[ -f "$CURSOR_STAMP" ]] || return 0
+
+  local old_name
+  while IFS= read -r old_name; do
+    [[ -n "$old_name" ]] || continue
+    local found=0 name
+    for name in "${current[@]}"; do
+      if [[ "$name" == "$old_name" ]]; then
+        found=1
+        break
+      fi
+    done
+    if [[ "$found" -eq 0 && -f "$CURSOR_RULES_DIR/$old_name" ]]; then
+      rm -f "$CURSOR_RULES_DIR/$old_name"
+      warn "Removed stale Cursor rule $CURSOR_RULES_DIR/$old_name"
+    fi
+  done <"$CURSOR_STAMP"
+}
+
 build_cursor_rules() {
   [[ -f "$MANIFEST" ]] || { echo "missing $MANIFEST" >&2; exit 1; }
   mkdir -p "$CURSOR_RULES_DIR"
 
+  local -a manifest_names=()
   local name source always_apply description
+  while IFS=$'\t' read -r name source always_apply description; do
+    [[ -z "$name" || "$name" == \#* ]] && continue
+    manifest_names+=("$name")
+  done <"$MANIFEST"
+
+  prune_removed_cursor_rules "${manifest_names[@]}"
+
   while IFS=$'\t' read -r name source always_apply description; do
     [[ -z "$name" || "$name" == \#* ]] && continue
     local src="$AGENT_DIR/$source"
@@ -39,16 +81,18 @@ build_cursor_rules() {
 
     local out="$CURSOR_RULES_DIR/$name"
     rm -f "$out"
-  {
-    printf '%s\n' '---'
-    printf 'description: %s\n' "$description"
-    printf 'alwaysApply: %s\n' "$always_apply"
-    printf '%s\n' '---'
-    printf '\n'
-    cat "$src"
-  } >"$out"
+    {
+      printf '%s\n' '---'
+      printf 'description: %s\n' "$description"
+      printf 'alwaysApply: %s\n' "$always_apply"
+      printf '%s\n' '---'
+      printf '\n'
+      cat "$src"
+    } >"$out"
     info "Built $out"
   done <"$MANIFEST"
+
+  printf '%s\n' "${manifest_names[@]}" >"$CURSOR_STAMP"
 }
 
 install_claude_adapter() {
@@ -61,14 +105,16 @@ install_claude_adapter() {
 install_mylab_index() {
   local mylab="$HOME/myLab"
   local template="$REPO_DIR/templates/mylab-AGENTS.md"
+  local claude_template="$REPO_DIR/adapters/mylab-CLAUDE.md"
   [[ -d "$mylab" ]] || {
     warn "\$HOME/myLab not found; skipping workspace AGENTS.md install"
     return 0
   }
   [[ -f "$template" ]] || { echo "missing $template" >&2; exit 1; }
+  [[ -f "$claude_template" ]] || { echo "missing $claude_template" >&2; exit 1; }
 
   link_file "$template" "$mylab/AGENTS.md"
-  link_file "$mylab/AGENTS.md" "$mylab/CLAUDE.md"
+  install_file "$claude_template" "$mylab/CLAUDE.md"
 }
 
 build_cursor_rules

--- a/sync-repos.sh
+++ b/sync-repos.sh
@@ -65,6 +65,21 @@ is_excluded() {
 
 log() { printf '%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "$LOG_FILE"; }
 
+# Resolve the remote default branch: prefer origin/HEAD after fetch, else main/master.
+resolve_default_branch() {
+  local branch=""
+  branch="$(git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)"
+  if [[ -z "$branch" ]]; then
+    for candidate in main master; do
+      if git rev-parse --verify "refs/remotes/origin/${candidate}" &>/dev/null; then
+        branch="$candidate"
+        break
+      fi
+    done
+  fi
+  printf '%s' "$branch"
+}
+
 sync_repo() {
   local repo_path="$1"
   local repo_name
@@ -78,20 +93,15 @@ sync_repo() {
     return 0
   fi
 
-  local default_branch=""
-  for candidate in main master; do
-    if git rev-parse --verify "refs/remotes/origin/${candidate}" &>/dev/null; then
-      default_branch="$candidate"
-      break
-    fi
-  done
-  if [[ -z "$default_branch" ]]; then
-    log "[$repo_name] SKIP - no origin/main or origin/master found"
+  if ! git fetch origin --prune --quiet 2>/dev/null; then
+    log "[$repo_name] SKIP - fetch failed (network/auth)"
     return 0
   fi
 
-  if ! git fetch origin "$default_branch" --prune --quiet 2>/dev/null; then
-    log "[$repo_name] SKIP - fetch failed (network/auth)"
+  local default_branch
+  default_branch="$(resolve_default_branch)"
+  if [[ -z "$default_branch" ]]; then
+    log "[$repo_name] SKIP - no default branch found (origin/HEAD, main, or master)"
     return 0
   fi
 

--- a/templates/mylab-AGENTS.md
+++ b/templates/mylab-AGENTS.md
@@ -19,7 +19,7 @@ Per-repo docs override this index for that repo.
 
 | Directory | Notes |
 | --- | --- |
-| `initMe/` | Dotfiles and bootstrap. Read `initMe/AGENTS.md` before editing scripts. Verify with `shellcheck *.sh`. |
+| `initMe/` | Dotfiles and bootstrap. Read `initMe/AGENTS.md` before editing scripts. Verify with `git ls-files '*.sh' \| xargs shellcheck`. |
 | `mechanical-watch-ui/` | Vanilla HTML/JS. No build step; open `index.html` in a browser. |
 | `apoorv-kulkarni.github.io/` | Jekyll site: `bundle install` then `bundle exec jekyll serve`. |
 | `demo/` | Java/Spring Boot: `./mvnw spring-boot:run`, `./mvnw test`. |

--- a/zshrc
+++ b/zshrc
@@ -24,7 +24,20 @@ source "$ZSH/oh-my-zsh.sh"
 # -----------------------------------------------------------------------------
 # PATH
 # -----------------------------------------------------------------------------
-export PATH="/usr/local/bin:/usr/local/sbin:$HOME/.local/bin:$PATH"
+# Homebrew (macOS): shellenv sets HOMEBREW_PREFIX and prepends brew paths.
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# tfenv / Go (Pi bootstrap installs to these paths; no-op if absent)
+[[ -d "$HOME/.tfenv/bin" ]] && export PATH="$HOME/.tfenv/bin:$PATH"
+[[ -d /usr/local/go/bin ]] && export PATH="/usr/local/go/bin:$PATH"
 
 # VS Code CLI (macOS only)
 [[ -d "/Applications/Visual Studio Code.app" ]] && \


### PR DESCRIPTION
## Summary

Addresses review findings 1-6:

1. **clone-mylab.sh** — skip directories that exist without `.git` (tarball install path)
2. **zshrc** — durable Homebrew `shellenv` on macOS; `tfenv` and Go paths on Pi/Linux
3. **ShellCheck** — added to Brewfile and `bootstrap-pi.sh` apt packages
4. **CI/docs** — `git ls-files '*.sh' | xargs shellcheck` everywhere
5. **sync-repos.sh** — fetch first, resolve default branch from `origin/HEAD`, fallback to main/master
6. **build-agent-adapters.sh** — prune stale generated `.mdc` via `.initme-managed-rules`; install `~/myLab/CLAUDE.md` as a copied file (`@AGENTS.md`) instead of symlink chain

## Test plan

- [x] `git ls-files '*.sh' | xargs shellcheck`
- [x] `bash scripts/build-agent-adapters.sh` (installs `~/myLab/CLAUDE.md` as file)
- [ ] Fresh Mac: curl install → `clone-mylab.sh` clones remaining repos
- [ ] New terminal: `brew`, `terraform`, `go` on PATH (Apple Silicon + Pi)