### PR TITLE
Fix install-macos.sh crash on macOS bash 3.2 with set -u

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -19,21 +19,18 @@ ohai()  { echo "==> $*"; }
 warn()  { echo "Warning: $*" >&2; }
 abort() { echo "initMe: $*" >&2; exit 1; }
 
-# Drop `bash -c "..." --` separator when using Homebrew-style invocations.
-ARGS=("$@")
-if [[ "${ARGS[0]:-}" == "--" ]]; then
-  ARGS=("${ARGS[@]:1}")
-fi
-
 # --- Parse args (path or bootstrap flags) ---
 MYLAB_DIR="${HOME}/myLab"
-BOOT_ARGS=()
 
-if [[ ${#ARGS[@]} -gt 0 && "${ARGS[0]:0:1}" != "-" ]]; then
-  MYLAB_DIR="${ARGS[0]}"
-  BOOT_ARGS=("${ARGS[@]:1}")
-else
-  BOOT_ARGS=("${ARGS[@]}")
+# Drop an optional separator for bash -c "..." -- style invocations.
+if [[ $# -gt 0 && "${1:-}" == "--" ]]; then
+  shift
+fi
+
+# First non-flag arg is the parent install dir.
+if [[ $# -gt 0 && "${1:0:1}" != "-" ]]; then
+  MYLAB_DIR="$1"
+  shift
 fi
 
 DEST="${MYLAB_DIR}/${REPO}"
@@ -89,4 +86,4 @@ echo ""
 
 ohai "Running bootstrap.sh"
 cd "$DEST"
-exec bash bootstrap.sh "${BOOT_ARGS[@]}"
+exec bash bootstrap.sh "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On macOS, `/bin/bash` is still version 3.2. With `set -u`, expanding an empty array as `"${arr[@]}"` is treated as an unbound variable (fixed in bash 4.4).

The curl installer parsed args into `ARGS` / `BOOT_ARGS` arrays. With no extra arguments, the no-arg path hit:

```bash
BOOT_ARGS=("${ARGS[@]}")
```

and failed with:

```
install-macos.sh: line 36: ARGS[@]: unbound variable
```

Stripping `-u` via `sed` works around this but disables nounset for the whole script.

## Fix

Refactor arg parsing to use `$@` and `shift` instead of arrays, then pass remaining positional args to bootstrap:

```bash
exec bash bootstrap.sh "$@"
```

This keeps `set -euo pipefail` and is compatible with stock macOS bash.

## Verification

- Handles no args, `-- --dry-run`, custom parent dir, and combined dir + flags.
- ShellCheck not available in this environment; CI should run on push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

