### PR TITLE
Fix Brewfile: install Vault from hashicorp/tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,7 +14,8 @@ brew "pyenv"
 
 # ── Infrastructure & secrets ──────────────────────────────────────────────────
 brew "tfenv"
-brew "vault"
+tap "hashicorp/tap"
+brew "hashicorp/tap/vault"
 
 # ── Kubernetes ────────────────────────────────────────────────────────────────
 brew "kubernetes-cli"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ On a fresh machine, bootstrap will:
 `gigithub_2024` and `github_rsa` as fallbacks. OpenSSH skips missing keys.
 `IdentitiesOnly yes` limits which keys are offered to GitHub.
 
-Vault is installed via Homebrew on macOS; log in manually when you need it (`vault login`).
+Vault is installed via HashiCorp’s Homebrew tap on macOS (`hashicorp/tap/vault`); log in manually when you need it (`vault login`).
 
 ## GPG commit signing (optional)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fresh Mac bootstrap fails at `brew bundle` with:

```
Error: No available formula with the name "vault". Did you mean vaulted?
```

HashiCorp Vault was removed from Homebrew core after the BUSL license change. The formula now lives in the official `hashicorp/tap`.

## Fix

- Add `tap "hashicorp/tap"` to the Brewfile
- Install via `brew "hashicorp/tap/vault"`
- Update README to mention the tap
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

