### PR TITLE
Install HashiCorp tools from official hashicorp/tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -12,9 +12,11 @@ brew "go"
 brew "pyenv"
 # brew "dotnet@9"   # uncomment when you need .NET
 
-# ── Infrastructure & secrets ──────────────────────────────────────────────────
-brew "tfenv"
-brew "vault"
+# ── Infrastructure (HashiCorp official tap) ───────────────────────────────────
+# homebrew-core removed HashiCorp formulae; use signed binaries from hashicorp/tap.
+tap "hashicorp/tap"
+brew "hashicorp/tap/terraform"
+brew "hashicorp/tap/vault"
 
 # ── Kubernetes ────────────────────────────────────────────────────────────────
 brew "kubernetes-cli"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ initMe/
 | --- | --- | --- |
 | Core packages | `brew bundle` (Brewfile) | `apt` + manual binaries |
 | Languages | Go, Python (pyenv) | Go, Python (pyenv) |
-| Infrastructure | Terraform (tfenv), Vault | Terraform (tfenv) |
+| Infrastructure | Terraform, Vault (`hashicorp/tap`) | Terraform (tfenv) |
 | Kubernetes | kubectl, kubectx, kubelogin, k9s, minikube | kubectl, kubectx, k9s |
 | Shell | oh-my-zsh + Powerlevel10k + plugins | oh-my-zsh + Powerlevel10k + plugins |
 | Dotfiles | `zshrc`, `p10k`, SSH, gitconfig include, global gitignore | `zshrc` + SSH symlinked |
@@ -135,7 +135,7 @@ On a fresh machine, bootstrap will:
 `gigithub_2024` and `github_rsa` as fallbacks. OpenSSH skips missing keys.
 `IdentitiesOnly yes` limits which keys are offered to GitHub.
 
-Vault is installed via Homebrew on macOS; log in manually when you need it (`vault login`).
+Terraform and Vault install via HashiCorp’s official Homebrew tap (`hashicorp/tap`) on macOS. Log into Vault manually when you need it (`vault login`).
 
 ## GPG commit signing (optional)
 

--- a/agent/references/coding-reference.md
+++ b/agent/references/coding-reference.md
@@ -28,8 +28,8 @@ Personal repos live under `~/myLab/`. Each project is usually independent
 - **YAML**: Kubernetes manifests, Helm charts
 - **Shell**: zsh/bash scripts for automation
 
-Infra tooling commonly available on a bootstrapped machine: Terraform (tfenv),
-Vault, kubectl, k9s, minikube.
+Infra tooling commonly available on a bootstrapped machine: Terraform, Vault
+(macOS via `hashicorp/tap`; Pi via tfenv), kubectl, k9s, minikube.
 
 ## Code standards
 
@@ -82,8 +82,8 @@ Vault, kubectl, k9s, minikube.
 
 ## Tools & aliases
 
-Installed via initMe bootstrap (`Brewfile`): `rg`, `jq`, `yq`, `gh`, `kubectl`,
-`k9s`, `terraform`, `vault`.
+Installed via initMe bootstrap (`Brewfile` / `bootstrap-pi.sh`): `rg`, `jq`, `yq`,
+`gh`, `kubectl`, `k9s`, `terraform`, `vault`.
 
 **Shell aliases** (from `~/myLab/initMe/zshrc`): `k` (kubectl), `ll`, `uuid`/`uuid1`.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STEP=0
-TOTAL=17
+TOTAL=16
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "bootstrap.sh is for macOS only. On Linux / Raspberry Pi, run: bash bootstrap-pi.sh"
@@ -76,18 +76,7 @@ step "Packages (Brewfile)"
 run brew bundle --file="$REPO_DIR/Brewfile"
 
 # -----------------------------------------------------------------------------
-# 4. Terraform (via tfenv)
-# -----------------------------------------------------------------------------
-step "Terraform"
-if ! tfenv list 2>/dev/null | grep -q '[0-9]'; then
-    echo "  Installing latest Terraform via tfenv..."
-    run tfenv install latest
-    run tfenv use latest
-fi
-$DRY_RUN || echo "  $(terraform version | head -1)"
-
-# -----------------------------------------------------------------------------
-# 5. Python (via pyenv)
+# 4. Python (via pyenv)
 # -----------------------------------------------------------------------------
 step "Python"
 if ! $DRY_RUN; then
@@ -108,7 +97,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 6. SSH key
+# 5. SSH key
 # -----------------------------------------------------------------------------
 step "SSH key"
 run mkdir -p "$HOME/.ssh"
@@ -146,7 +135,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 7. GitHub CLI auth
+# 6. GitHub CLI auth
 # -----------------------------------------------------------------------------
 step "GitHub CLI"
 if ! gh auth status &>/dev/null; then
@@ -161,7 +150,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 8. oh-my-zsh
+# 7. oh-my-zsh
 # -----------------------------------------------------------------------------
 step "oh-my-zsh"
 if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
@@ -172,7 +161,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 9. Powerlevel10k theme
+# 8. Powerlevel10k theme
 # -----------------------------------------------------------------------------
 step "Powerlevel10k"
 P10K_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
@@ -184,7 +173,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 10. zsh plugins
+# 9. zsh plugins
 # -----------------------------------------------------------------------------
 step "zsh plugins"
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
@@ -198,7 +187,7 @@ for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
 done
 
 # -----------------------------------------------------------------------------
-# 11. zshrc — symlink so edits stay in sync with the repo
+# 10. zshrc — symlink so edits stay in sync with the repo
 # -----------------------------------------------------------------------------
 step "zshrc"
 if [[ -f "$HOME/.zshrc" && ! -L "$HOME/.zshrc" ]]; then
@@ -228,7 +217,7 @@ if [[ -f "$REPO_DIR/git/gitconfig" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 12. macOS defaults
+# 11. macOS defaults
 # -----------------------------------------------------------------------------
 step "macOS defaults"
 DEFAULTS_MARKER="$HOME/.config/initme/defaults_applied"
@@ -275,7 +264,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 13. Repo sync — launchd agent (runs every 6 hours)
+# 12. Repo sync — launchd agent (runs every 6 hours)
 # -----------------------------------------------------------------------------
 step "Repo sync (launchd)"
 PLIST_LABEL="com.apoorv.sync-repos"
@@ -319,7 +308,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 14. iTerm2 profile
+# 13. iTerm2 profile
 # -----------------------------------------------------------------------------
 step "iTerm2 profile"
 if [[ -f "$REPO_DIR/iterm2_profile.plist" ]]; then
@@ -330,7 +319,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 15. VS Code extensions
+# 14. VS Code extensions
 # -----------------------------------------------------------------------------
 step "VS Code extensions"
 if command -v code &>/dev/null; then
@@ -344,7 +333,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 16. Git config
+# 15. Git config
 # -----------------------------------------------------------------------------
 step "Git config"
 if [[ -z "$(git config --global user.name 2>/dev/null)" ]]; then
@@ -368,7 +357,7 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 17. Agent rules (canonical agent/ -> Cursor, Claude, myLab index)
+# 16. Agent rules (canonical agent/ -> Cursor, Claude, myLab index)
 # -----------------------------------------------------------------------------
 step "Agent rules"
 run bash "$REPO_DIR/scripts/build-agent-adapters.sh"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fresh Mac bootstrap fails at `brew bundle`:

```
Error: No available formula with the name "vault"
```

HashiCorp removed Terraform, Vault, and related formulae from Homebrew core after the BUSL license change. The old Brewfile used `brew "vault"` and `brew "tfenv"`.

## Approach

Use HashiCorp’s official Homebrew tap for macOS — signed binaries, maintained by HashiCorp, same as their [packaging guide](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary).

```ruby
tap "hashicorp/tap"
brew "hashicorp/tap/terraform"
brew "hashicorp/tap/vault"
```

## Changes

- **Brewfile**: switch from broken core formulae to `hashicorp/tap`
- **bootstrap.sh**: drop redundant post-bundle tfenv/terraform step (brew bundle installs both tools)
- **Pi unchanged**: still uses tfenv (no Homebrew on Pi bootstrap)
- **Docs**: note macOS uses `hashicorp/tap`; Pi keeps tfenv

## Tradeoffs

| | `hashicorp/tap` (this PR) | `tfenv` on macOS |
|---|---|---|
| Source | Official signed binaries | Community version manager |
| Versions | Latest GA from tap | Switch versions per project |
| Bootstrap | Single `brew bundle` step | Brewfile + extra bootstrap step |

If you need multiple Terraform versions on macOS later, we can add tfenv back alongside the tap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

