### PR TITLE
Fix brew bundle tap trust and parallel install locks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,9 +14,9 @@ brew "pyenv"
 
 # ── Infrastructure (HashiCorp official tap) ───────────────────────────────────
 # homebrew-core removed HashiCorp formulae; use signed binaries from hashicorp/tap.
-tap "hashicorp/tap"
-brew "hashicorp/tap/terraform"
-brew "hashicorp/tap/vault"
+tap "hashicorp/tap", trusted: true
+brew "hashicorp/tap/terraform", trusted: true
+brew "hashicorp/tap/vault", trusted: true
 
 # ── Kubernetes ────────────────────────────────────────────────────────────────
 brew "kubernetes-cli"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ On a fresh machine, bootstrap will:
 `gigithub_2024` and `github_rsa` as fallbacks. OpenSSH skips missing keys.
 `IdentitiesOnly yes` limits which keys are offered to GitHub.
 
-Terraform and Vault install via HashiCorp’s official Homebrew tap (`hashicorp/tap`) on macOS. Log into Vault manually when you need it (`vault login`).
+Terraform and Vault install via HashiCorp’s official Homebrew tap (`hashicorp/tap`, declared as trusted in the Brewfile). Log into Vault manually when you need it (`vault login`).
 
 ## GPG commit signing (optional)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,7 +73,8 @@ echo "  Ready at: $(brew --prefix 2>/dev/null || echo '(brew not yet installed)'
 # 3. Packages — brew bundle
 # -----------------------------------------------------------------------------
 step "Packages (Brewfile)"
-run brew bundle --file="$REPO_DIR/Brewfile"
+# Sequential installs avoid Homebrew 6.x parallel lock races (e.g. go vs gh).
+run brew bundle --file="$REPO_DIR/Brewfile" --jobs 1
 
 # -----------------------------------------------------------------------------
 # 4. Python (via pyenv)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fresh Mac bootstrap fails at `brew bundle` in two ways on Homebrew 6.x:

1. **Untrusted tap**
   ```
   Error: Refusing to load formula hashicorp/tap/terraform from untrusted tap hashicorp/tap.
   ```

2. **Parallel install lock race**
   ```
   Error: A `brew install --formula gh` process has already locked /opt/homebrew/Cellar/go.
   ```

## Fix

- Declare `trusted: true` on `hashicorp/tap` and its formulae in the Brewfile (Homebrew's supported declarative trust syntax)
- Run `brew bundle --jobs 1` in `bootstrap.sh` so formula installs are sequential and do not fight over shared dependency locks

## Recovery (current partial install)

After merging, from the existing tarball checkout:

```bash
cd ~/myLab/initMe
git pull   # or re-download after merge
bash bootstrap.sh
```

Bootstrap is idempotent — it skips already-installed packages and continues.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

