### PR TITLE
Automate post-bootstrap git clone, repo sync, and exec zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Targets: **macOS** (`bootstrap.sh`) and **Raspberry Pi OS** (`bootstrap-pi.sh`).
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/apoorv-kulkarni/initMe/HEAD/install-macos.sh)"
 ```
 
-Then clone the rest of your repos:
+Then clone the rest of your repos (or let bootstrap do it automatically):
 
 ```bash
 cd ~/myLab/initMe
-bash clone-mylab.sh
+bash clone-mylab.sh   # optional if bootstrap already ran step 18
 exec zsh
 ```
 
-The curl installer leaves `initMe` without `.git` until you convert it to a real
-clone (steps printed at the end of `install-macos.sh`). `sync-repos.sh` cannot
-update initMe until then. After `gh auth login`, run those conversion steps, or
-use `git clone` instead of the curl path if you prefer a git checkout from the start.
+The curl installer leaves `initMe` without `.git` until bootstrap converts it to a real
+clone (step 17). `sync-repos.sh` cannot update initMe until then. After `gh auth login`,
+bootstrap handles conversion automatically, or use `git clone` instead of the curl path
+if you prefer a git checkout from the start.
 
 ### On a machine that already has tools installed
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # =============================================================================
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INITME_GIT_REMOTE="git@github.com:apoorv-kulkarni/initMe.git"
+INITME_DEFAULT_BRANCH="master"
 STEP=0
-TOTAL=16
+TOTAL=18
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "bootstrap.sh is for macOS only. On Linux / Raspberry Pi, run: bash bootstrap-pi.sh"
@@ -364,8 +366,41 @@ step "Agent rules"
 run bash "$REPO_DIR/scripts/build-agent-adapters.sh"
 
 # -----------------------------------------------------------------------------
+# 17. Tarball install → git clone (enables sync-repos.sh to update initMe)
+# -----------------------------------------------------------------------------
+step "initMe git clone"
+if [[ -d "$REPO_DIR/.git" ]]; then
+    echo "  Already a git clone."
+elif ! $DRY_RUN; then
+    echo "  Converting tarball checkout to git@github.com:apoorv-kulkarni/initMe.git ..."
+    (
+        cd "$REPO_DIR"
+        git init
+        git remote add origin "$INITME_GIT_REMOTE"
+        git fetch origin
+        git reset --hard FETCH_HEAD
+        git branch -M "$INITME_DEFAULT_BRANCH"
+    )
+    echo "  Done. sync-repos.sh can update initMe on future runs."
+else
+    echo "  [dry-run] would run: git init && git fetch origin && git reset --hard FETCH_HEAD"
+fi
+
+# -----------------------------------------------------------------------------
+# 18. Clone ~/myLab repos (SSH + gh auth must be done)
+# -----------------------------------------------------------------------------
+step "Clone myLab repos"
+run bash "$REPO_DIR/clone-mylab.sh"
+
+# -----------------------------------------------------------------------------
 echo ""
 echo "All done! Next steps:"
-echo "  1. Open a new terminal — all shell settings take effect"
+if ! $DRY_RUN && [[ -t 0 ]] && [[ "${BOOTSTRAP_NO_EXEC_ZSH:-}" != 1 ]]; then
+    echo "  1. Starting zsh with your new configuration..."
+    echo "  2. Run 'p10k configure' to set up your prompt style"
+    echo "     (or copy your .p10k.zsh from your old machine to skip this)"
+    exec zsh -l
+fi
+echo "  1. Run 'exec zsh' — shell settings take effect in a new session"
 echo "  2. Run 'p10k configure' to set up your prompt style"
 echo "     (or copy your .p10k.zsh from your old machine to skip this)"

--- a/clone-mylab.sh
+++ b/clone-mylab.sh
@@ -45,5 +45,4 @@ clone_if_missing "https://github.com/rdeepak2002/reddit-place-script-2022.git"
 
 echo ""
 echo -e "${GREEN}Done.${NC} Workspace is at $MYLAB_DIR"
-echo "Next: cd $MYLAB_DIR/initMe && bash install.sh   # symlink dotfiles + Cursor rules"
-echo "       bash bootstrap.sh                         # full new-machine setup (macOS)"
+echo "Open ~/myLab in Cursor, then run 'p10k configure' if you have not already."

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -77,11 +77,7 @@ trap - EXIT
 cleanup
 
 ohai "Installed to $DEST"
-warn "Tarball install has no .git yet. bootstrap.sh will install git."
-echo "After gh auth login, convert to a normal clone:"
-echo "  cd $DEST"
-echo "  git init && git remote add origin git@github.com:${OWNER}/${REPO}.git"
-echo "  git fetch origin && git reset --hard FETCH_HEAD && git branch -M master"
+warn "Tarball install has no .git yet; bootstrap.sh will convert it after GitHub auth."
 echo ""
 
 ohai "Running bootstrap.sh"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Automates the manual post-bootstrap steps from a fresh curl install.

## New bootstrap steps (after GitHub auth + agent rules)

| Step | What | Notes |
|------|------|-------|
| **17** | Convert tarball `initMe` → git clone | Only when `.git` is missing; enables `sync-repos.sh` |
| **18** | Run `clone-mylab.sh` | Idempotent; skips already-cloned repos |
| **End** | `exec zsh -l` | Only on an interactive TTY; set `BOOTSTRAP_NO_EXEC_ZSH=1` to skip |

## Also updated

- `install-macos.sh` — points to bootstrap for git conversion instead of manual commands
- `clone-mylab.sh` / README — refreshed next-step messaging
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

