### PR TITLE
Add Claude, ChatGPT, and DuckDuckGo to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -38,13 +38,22 @@ brew "zsh-autosuggestions"
 brew "zsh-syntax-highlighting"
 
 # ── Apps ──────────────────────────────────────────────────────────────────────
+# Browsers
 cask "firefox"
 cask "google-chrome"
-cask "iterm2"
+cask "duckduckgo"
+
+# AI
 cask "cursor"
+cask "claude-code"
+cask "claude"
+cask "chatgpt"
+
+# Terminal, editors, and utilities
+cask "iterm2"
+cask "visual-studio-code"
 cask "slack"
 cask "zoom"
 cask "spotify"
-cask "visual-studio-code"
 cask "font-hack-nerd-font"
 cask "1password-cli"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ initMe/
 | GitHub CLI | Install + `gh auth login` | Install + `gh auth login` |
 | macOS defaults | Finder, key repeat, Dock, screenshots (prompted) | — |
 | iTerm2 | Profile imported from repo | — |
-| Editors | VS Code + Cursor (casks); VS Code extensions from list | — |
+| Editors & AI | VS Code, Cursor, Claude Code, Claude, ChatGPT (casks); VS Code extensions from list | — |
 | Repo sync | launchd every 6h: ff-only `main`/`master` under `~/myLab` | cron every 6h |
 | CI | ShellCheck on push (`.github/workflows/shellcheck.yml`) | — |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds native macOS apps to the Brewfile for tools with active paid subscriptions and DuckDuckGo as an additional browser.

## New casks

| Cask | App |
|------|-----|
| `claude-code` | Claude Code CLI |
| `claude` | Claude desktop (Chat, Cowork, Code) |
| `chatgpt` | ChatGPT desktop |
| `duckduckgo` | DuckDuckGo browser |

`cursor` remains the primary IDE agent; initMe already configures Claude Code via `~/.claude/CLAUDE.md`.

## Brewfile layout

App casks are grouped into browsers, AI, and utilities for easier maintenance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b8a-ec2f-7af5-9451-c143f28d553e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

