### PR TITLE
Add genpass shell function to zshrc

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -108,6 +108,36 @@ random-string() {
   LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 32 | head -n 1
 }
 
+# Generate a random password of a specified length (default: 20) with at least
+# one lowercase letter, one uppercase letter, one digit, and one special character.
+# Usage: genpass [length]
+genpass() {
+    local length="${1:-20}"
+    local alphabet='A-Za-z0-9!@#$%^&*()_+=-'
+    local password
+
+    if ! [[ "$length" =~ ^[0-9]+$ ]] || (( length < 8 )); then
+        echo "Usage: genpass [length]" >&2
+        echo "Length must be an integer of at least 8." >&2
+        return 1
+    fi
+
+    while true; do
+        password="$(
+            LC_ALL=C tr -dc "$alphabet" < /dev/urandom |
+                head -c "$length"
+        )"
+
+        if printf '%s' "$password" | grep -q '[a-z]' &&
+           printf '%s' "$password" | grep -q '[A-Z]' &&
+           printf '%s' "$password" | grep -q '[0-9]' &&
+           printf '%s' "$password" | grep -q '[!@#$%^&*()_+=-]'; then
+            printf '%s\n' "$password"
+            return 0
+        fi
+    done
+}
+
 # Generate one or more UUIDs (lowercase)
 # Usage: uuid [count]
 uuid() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `genpass` helper to the Functions section of `zshrc`, alongside `random-string` and `uuid`.

**Usage:** `genpass [length]`

- Default length: 20
- Minimum length: 8
- Guarantees at least one lowercase letter, uppercase letter, digit, and special character from `!@#$%^&*()_+=-`

After `install.sh` / bootstrap symlink refresh (or a new shell with the symlinked `zshrc`), call `genpass` or `genpass 32` from zsh.

Commit author is set to your GitHub identity (not Cursor Agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5d5b-a39b-717f-81fd-5f31c68a1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5d5b-a39b-717f-81fd-5f31c68a1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

